### PR TITLE
Fix PDF File corrupted exception

### DIFF
--- a/android-pdfview/src/main/java/com/joanzapata/pdfview/DecodingAsyncTask.java
+++ b/android-pdfview/src/main/java/com/joanzapata/pdfview/DecodingAsyncTask.java
@@ -47,9 +47,14 @@ class DecodingAsyncTask extends AsyncTask<Void, Void, Void> {
 
     @Override
     protected Void doInBackground(Void... params) {
-        decodeService = new DecodeServiceBase(new PdfContext());
-        decodeService.setContentResolver(pdfView.getContext().getContentResolver());
-        decodeService.open(uri);
+        try {
+            decodeService = new DecodeServiceBase(new PdfContext());
+            decodeService.setContentResolver(pdfView.getContext().getContentResolver());
+            decodeService.open(uri);
+        } catch (Exception e){
+            // Prevent  java.lang.RuntimeException: PDF file is corrupted
+            this.cancelled = true;
+        }
         return null;
     }
 


### PR DESCRIPTION
Hi
this fix prevent the lib to crash on RuntimeException File corrupted.
it's a basic try - catch that set cancelled to true, to cancel the process.

here is the full trace:

java.lang.RuntimeException: An error occured while executing doInBackground()
       at android.os.AsyncTask$3.done(AsyncTask.java:300)
       at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:355)
       at java.util.concurrent.FutureTask.setException(FutureTask.java:222)
       at java.util.concurrent.FutureTask.run(FutureTask.java:242)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
       at java.lang.Thread.run(Thread.java:818)
Caused by: java.lang.RuntimeException: PDF file is corrupted
       at org.vudroid.pdfdroid.codec.PdfDocument.open(PdfDocument.java)
       at org.vudroid.pdfdroid.codec.PdfDocument.openDocument(PdfDocument.java:28)
       at org.vudroid.pdfdroid.codec.PdfContext.openDocument(PdfContext.java:18)
       at org.vudroid.core.DecodeServiceBase.open(DecodeServiceBase.java:59)
       at com.joanzapata.pdfview.DecodingAsyncTask.doInBackground(DecodingAsyncTask.java:52)
       at com.joanzapata.pdfview.DecodingAsyncTask.doInBackground(DecodingAsyncTask.java:31)
       at android.os.AsyncTask$2.call(AsyncTask.java:288)
       at java.util.concurrent.FutureTask.run(FutureTask.java:237)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
       at java.lang.Thread.run(Thread.java:818)
